### PR TITLE
open more information links in new tab

### DIFF
--- a/templates/kronos.html
+++ b/templates/kronos.html
@@ -58,7 +58,7 @@
                      </center>
                     </p>
                       <center>
-                        <button type="button" class="btn btn-success" onclick="location.href = '{{Cwikilink}}';">MetaKGP wiki for course: {{courseCode}}</button>
+                        <button type="button" class="btn btn-success" onclick="window.open('{{Cwikilink}}', '_blank');">MetaKGP wiki for course: {{courseCode}}</button>
                       </center>
                 </div>
                 {% elif result=='invalid-code' %}
@@ -75,7 +75,7 @@
         </div>
 
         <div id="footer">
-            Contribute to this project on <a href="https://github.com/metakgp"><u>Github</u></a> | Powered by <a href="https://metakgp.github.io/"><u>metakgp</u></a> with <span style="font-size:150%;color:red;">♥</span>
+            Contribute to this project on <a href="https://github.com/metakgp" target="_blank"><u>Github</u></a> | Powered by <a href="https://metakgp.github.io/" target="_blank"><u>metakgp</u></a> with <span style="font-size:150%;color:red;">♥</span>
         </div>
 
 


### PR DESCRIPTION
Currently, we open the link for more information (such as wiki course page) in the same tab as the grade results.

This leads to distraction and it is mostly the case that one would want to keep both things open at the same time.

Hence, we should be adding `target="_blank"` to our anchor tags and replacing location.href with window function.